### PR TITLE
Add increment and decrement methods metrics

### DIFF
--- a/pkg/metrics/collectors/gauge.go
+++ b/pkg/metrics/collectors/gauge.go
@@ -24,3 +24,39 @@ func (g *Gauge) Update(collector prometheus.Collector, value float64, labels ...
 
 	return fmt.Errorf("invalid metric type, expected Gauge")
 }
+
+func (g *Gauge) Inc(collector prometheus.Collector, labels ...string) error {
+	if len(labels) > 0 {
+		if metricVec, ok := collector.(*prometheus.GaugeVec); ok {
+			metric := metricVec.WithLabelValues(labels...)
+			metric.Inc()
+			return nil
+		}
+		return fmt.Errorf("invalid metric type, expected GaugeVec for labels")
+	}
+
+	if metric, ok := collector.(prometheus.Gauge); ok {
+		metric.Inc()
+		return nil
+	}
+
+	return fmt.Errorf("invalid metric type, expected Gauge")
+}
+
+func (g *Gauge) Dec(collector prometheus.Collector, labels ...string) error {
+	if len(labels) > 0 {
+		if metricVec, ok := collector.(*prometheus.GaugeVec); ok {
+			metric := metricVec.WithLabelValues(labels...)
+			metric.Dec()
+			return nil
+		}
+		return fmt.Errorf("invalid metric type, expected GaugeVec for labels")
+	}
+
+	if metric, ok := collector.(prometheus.Gauge); ok {
+		metric.Dec()
+		return nil
+	}
+
+	return fmt.Errorf("invalid metric type, expected Gauge")
+}

--- a/pkg/metrics/collectors/gauge_test.go
+++ b/pkg/metrics/collectors/gauge_test.go
@@ -15,3 +15,21 @@ func TestGaugeUpdate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, float64(15), testutil.ToFloat64(gauge))
 }
+
+func TestGaugeInc(t *testing.T) {
+	gauge := prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_gauge"})
+	g := &Gauge{}
+
+	err := g.Inc(gauge)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(1), testutil.ToFloat64(gauge))
+}
+
+func TestGaugeDec(t *testing.T) {
+	gauge := prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_gauge"})
+	g := &Gauge{}
+
+	err := g.Dec(gauge)
+	assert.NoError(t, err)
+	assert.Equal(t, float64(-1), testutil.ToFloat64(gauge))
+}

--- a/pkg/metrics/handler.go
+++ b/pkg/metrics/handler.go
@@ -1,8 +1,8 @@
 package metrics
 
 import (
+	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/zap"
 )
 
 type MetricHandler interface {
@@ -10,16 +10,48 @@ type MetricHandler interface {
 	Type() string
 }
 
-func (t *taskMetrics) UpdateMetric(name string, value float64, labels ...string) {
+type IncrementDecrementHandler interface {
+	MetricHandler
+	Inc(collector prometheus.Collector, labels ...string) error
+	Dec(collector prometheus.Collector, labels ...string) error
+}
+
+func (t *taskMetrics) performMetricAction(name string, action func(MetricHandler, prometheus.Collector, ...string) error, labels ...string) error {
 	t.mux.RLock()
 	metricDetail, ok := t.metrics[name]
 	t.mux.RUnlock()
+
 	if !ok {
-		zap.S().Errorf("Error: Metric not found for %s", name)
-		return
+		return fmt.Errorf("error: Metric not found for %s", name)
 	}
 
-	if err := metricDetail.Handler.Update(metricDetail.Collector, value, labels...); err != nil {
-		zap.S().Errorf("Error updating metric %s. Err: %s", name, err.Error())
+	if err := action(metricDetail.Handler, metricDetail.Collector, labels...); err != nil {
+		return fmt.Errorf("error performing action on metric %s. Err: %s", name, err.Error())
 	}
+
+	return nil
+}
+
+func (t *taskMetrics) UpdateMetric(name string, value float64, labels ...string) error {
+	return t.performMetricAction(name, func(h MetricHandler, c prometheus.Collector, labels ...string) error {
+		return h.Update(c, value, labels...)
+	}, labels...)
+}
+
+func (t *taskMetrics) IncrementMetric(name string, labels ...string) error {
+	return t.performMetricAction(name, func(h MetricHandler, c prometheus.Collector, labels ...string) error {
+		if incDecHandler, ok := h.(IncrementDecrementHandler); ok {
+			return incDecHandler.Inc(c, labels...)
+		}
+		return fmt.Errorf("error: Metric %s cannot be incremented", name)
+	}, labels...)
+}
+
+func (t *taskMetrics) DecrementMetric(name string, labels ...string) error {
+	return t.performMetricAction(name, func(h MetricHandler, c prometheus.Collector, labels ...string) error {
+		if incDecHandler, ok := h.(IncrementDecrementHandler); ok {
+			return incDecHandler.Dec(c, labels...)
+		}
+		return fmt.Errorf("error: Metric %s cannot be decremented", name)
+	}, labels...)
 }

--- a/pkg/metrics/handler_test.go
+++ b/pkg/metrics/handler_test.go
@@ -1,10 +1,25 @@
 package metrics
 
 import (
+	"fmt"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 	"testing"
 )
+
+type MetricsTestSuite struct {
+	suite.Suite
+	mockH *mockHandler
+}
+
+func (suite *MetricsTestSuite) SetupTest() {
+	suite.mockH = new(mockHandler)
+}
+
+func TestMetricsTestSuite(t *testing.T) {
+	suite.Run(t, new(MetricsTestSuite))
+}
 
 type mockHandler struct {
 	mock.Mock
@@ -15,31 +30,89 @@ func (m *mockHandler) Update(collector prometheus.Collector, value float64, labe
 	return args.Error(0)
 }
 
+func (m *mockHandler) Inc(collector prometheus.Collector, labels ...string) error {
+	args := m.Called(collector, labels)
+	return args.Error(0)
+}
+
+func (m *mockHandler) Dec(collector prometheus.Collector, labels ...string) error {
+	args := m.Called(collector, labels)
+	return args.Error(0)
+}
+
 func (m *mockHandler) Type() string {
 	args := m.Called()
 	return args.String(0)
 }
 
-func TestUpdateMetric(t *testing.T) {
-	mockH := new(mockHandler)
-
+func (suite *MetricsTestSuite) TestUpdateMetric() {
 	realCounter := prometheus.NewCounter(prometheus.CounterOpts{
 		Name: "test_counter",
 		Help: "Test counter",
 	})
-
-	metricDetail := MetricDetail{
-		Collector: realCounter,
-		Handler:   mockH,
-	}
-
 	taskMetric := &taskMetrics{
 		metrics: make(map[string]MetricDetail),
 	}
-	taskMetric.metrics["test_metric"] = metricDetail
+	taskMetric.metrics["test_metric"] = MetricDetail{
+		Collector: realCounter,
+		Handler:   suite.mockH,
+	}
+	suite.mockH.On("Update", realCounter, 1.0, mock.Anything).Return(nil).Once()
+	err := taskMetric.UpdateMetric("test_metric", 1.0)
+	suite.Nil(err)
+	suite.mockH.AssertExpectations(suite.T())
+}
 
-	mockH.On("Update", realCounter, 1.0, mock.Anything).Return(nil).Once()
+func (suite *MetricsTestSuite) TestIncrementMetric() {
+	realGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "test_gauge",
+		Help: "Test gauge",
+	})
+	taskMetric := &taskMetrics{
+		metrics: make(map[string]MetricDetail),
+	}
+	taskMetric.metrics["test_metric"] = MetricDetail{
+		Collector: realGauge,
+		Handler:   suite.mockH,
+	}
+	suite.mockH.On("Inc", realGauge, mock.Anything).Return(nil).Once()
+	err := taskMetric.IncrementMetric("test_metric")
+	suite.Nil(err)
+	suite.mockH.AssertExpectations(suite.T())
+}
 
-	taskMetric.UpdateMetric("test_metric", 1.0)
-	mockH.AssertExpectations(t)
+func (suite *MetricsTestSuite) TestDecrementMetric() {
+	realGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "test_gauge",
+		Help: "Test gauge",
+	})
+	taskMetric := &taskMetrics{
+		metrics: make(map[string]MetricDetail),
+	}
+	taskMetric.metrics["test_metric"] = MetricDetail{
+		Collector: realGauge,
+		Handler:   suite.mockH,
+	}
+	suite.mockH.On("Dec", realGauge, mock.Anything).Return(nil).Once()
+	err := taskMetric.DecrementMetric("test_metric")
+	suite.Nil(err)
+	suite.mockH.AssertExpectations(suite.T())
+}
+
+func (suite *MetricsTestSuite) TestIncrementNonGaugeMetric() {
+	realCounter := prometheus.NewCounter(prometheus.CounterOpts{
+		Name: "test_counter",
+		Help: "Test counter",
+	})
+	taskMetric := &taskMetrics{
+		metrics: make(map[string]MetricDetail),
+	}
+	taskMetric.metrics["test_metric"] = MetricDetail{
+		Collector: realCounter,
+		Handler:   suite.mockH,
+	}
+	suite.mockH.On("Inc", realCounter, mock.Anything).Return(fmt.Errorf("Error: Metric test_metric cannot be incremented")).Once()
+	err := taskMetric.IncrementMetric("test_metric")
+	suite.Error(err)
+	suite.mockH.AssertExpectations(suite.T())
 }

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -18,7 +18,9 @@ import (
 type TaskMetrics interface {
 	Start() error
 	RegisterMetric(name string, help string, labels []string, handler MetricHandler) error
-	UpdateMetric(name string, value float64, labels ...string)
+	UpdateMetric(name string, value float64, labels ...string) error
+	IncrementMetric(name string, labels ...string) error
+	DecrementMetric(name string, labels ...string) error
 	Name() string
 	Stop() error
 }

--- a/pkg/metrics/readme.md
+++ b/pkg/metrics/readme.md
@@ -31,8 +31,8 @@ This project provides a comprehensive metrics collection and reporting framework
 ## Code Structure
 
 - `/metrics/collectors/`: Contains the implementation of various metrics collectors (Counter, Gauge, Histogram).
-- `/metrics/handler.go`: Contains the MetricHandler interface and taskMetrics `UpdateMetric` method for updating metrics.
-- `/metrics/prometheus.go`: Defines the Prometheus server
+- `/metrics/handler.go`: Contains the MetricHandler interface and taskMetrics `UpdateMetric`, `IncrementMetric`, and `DecrementMetric` methods for updating metrics.
+- `/metrics/prometheus.go`: Defines the Prometheus server.
 - `/metrics/register.go`: Responsible for registering metrics with the Prometheus server.
 
 ## Metrics Collectors
@@ -46,7 +46,7 @@ This project provides a comprehensive metrics collection and reporting framework
 ### Gauge
 
 - **File**: `/metrics/collectors/gauge.go`
-- **Methods**: `Update`
+- **Methods**: `Update`, `Inc`, `Dec`
 - **Usage**: Gauges are metrics that can arbitrarily go up and down.
 
 ### Histogram
@@ -76,9 +76,8 @@ err = metricsServer.RegisterMetric("my_counter", "This is a counter metric", nil
 // With labels
 err = metricsServer.RegisterMetric("my_counter_with_labels", "This is a counter metric with labels", []string{"label1", "label2"}, &collectors.Counter{})
 
-if err != nil {
-log.Fatal(err)
-}
+// Register a gauge
+err = metricsServer.RegisterMetric("my_gauge", "This is a gauge metric", nil, &collectors.Gauge{})
 ```
 
 ### Updating Metrics
@@ -89,4 +88,10 @@ metricsServer.UpdateMetric("my_counter", 1)
 
 // With labels
 metricsServer.UpdateMetric("my_counter_with_labels", 1, "label1_value", "label2_value")
+
+// Increment a gauge
+metricsServer.IncrementMetric("my_gauge")
+
+// Decrement a gauge
+metricsServer.DecrementMetric("my_gauge")
 ```


### PR DESCRIPTION
## Add Increment and Decrement Functionality to Metrics

### Description

This Pull Request introduces the capability to increment and decrement Gauge metrics. The key changes include:

1. Addition of a new interface, `IncrementDecrementHandler`, that extends the existing `MetricHandler` interface to include `Inc()` and `Dec()` methods.
2. Modification of `taskMetrics` to include `IncrementMetric` and `DecrementMetric` methods.
3. Elimination of code repetition in `taskMetrics` through refactoring.
4. Update of unit tests in `handler_test.go` to cover the new increment and decrement functionalities.
