### PR TITLE
Refactor InitGlobalLogger to Accept String Level Argument

### DIFF
--- a/cmd/demo-metrics/main.go
+++ b/cmd/demo-metrics/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	println("[Demo] Microservice example")
 
-	cli.InitGlobalLogger()
+	cli.InitGlobalLogger(cli.DebugLevel)
 
 	r := runner.NewRunner()
 

--- a/cmd/demo-metrics/main.go
+++ b/cmd/demo-metrics/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	println("[Demo] Microservice example")
 
-	cli.InitGlobalLogger(cli.DebugLevel)
+	_, _ = cli.InitGlobalLogger(cli.DebugLevel)
 
 	r := runner.NewRunner()
 

--- a/cmd/demo-panic/main.go
+++ b/cmd/demo-panic/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	println("[Demo] Panic handler")
 
-	cli.InitGlobalLogger(cli.DebugLevel)
+	_, _ = cli.InitGlobalLogger(cli.DebugLevel)
 
 	r := runner.NewRunner()
 

--- a/cmd/demo-panic/main.go
+++ b/cmd/demo-panic/main.go
@@ -9,7 +9,7 @@ import (
 func main() {
 	println("[Demo] Panic handler")
 
-	cli.InitGlobalLogger()
+	cli.InitGlobalLogger(cli.DebugLevel)
 
 	r := runner.NewRunner()
 

--- a/pkg/cli/logging.go
+++ b/pkg/cli/logging.go
@@ -1,9 +1,11 @@
 package cli
 
 import (
+	"errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"os"
+	"strings"
 )
 
 const (
@@ -24,10 +26,10 @@ var stringToLevel = map[string]zapcore.Level{
 	PanicLevel: zapcore.PanicLevel,
 }
 
-func InitGlobalLogger(level string) *zap.Logger {
-	zapLevel, ok := stringToLevel[level]
+func InitGlobalLogger(level string) (*zap.Logger, error) {
+	zapLevel, ok := stringToLevel[strings.ToLower(level)]
 	if !ok {
-		zapLevel = zapcore.DebugLevel
+		return nil, errors.New("log level '%s' is incorrect")
 	}
 
 	encoderConfig := zap.NewProductionEncoderConfig()
@@ -40,5 +42,5 @@ func InitGlobalLogger(level string) *zap.Logger {
 
 	zap.ReplaceGlobals(logger)
 
-	return logger
+	return logger, nil
 }

--- a/pkg/cli/logging.go
+++ b/pkg/cli/logging.go
@@ -6,13 +6,36 @@ import (
 	"os"
 )
 
-func InitGlobalLogger() *zap.Logger {
+const (
+	DebugLevel = "debug"
+	InfoLevel  = "info"
+	WarnLevel  = "warn"
+	ErrorLevel = "error"
+	FatalLevel = "fatal"
+	PanicLevel = "panic"
+)
+
+var stringToLevel = map[string]zapcore.Level{
+	DebugLevel: zapcore.DebugLevel,
+	InfoLevel:  zapcore.InfoLevel,
+	WarnLevel:  zapcore.WarnLevel,
+	ErrorLevel: zapcore.ErrorLevel,
+	FatalLevel: zapcore.FatalLevel,
+	PanicLevel: zapcore.PanicLevel,
+}
+
+func InitGlobalLogger(level string) *zap.Logger {
+	zapLevel, ok := stringToLevel[level]
+	if !ok {
+		zapLevel = zapcore.DebugLevel
+	}
+
 	encoderConfig := zap.NewProductionEncoderConfig()
 	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
 	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
 	encoder := zapcore.NewConsoleEncoder(encoderConfig)
 
-	core := zapcore.NewCore(encoder, os.Stdout, zapcore.DebugLevel)
+	core := zapcore.NewCore(encoder, os.Stdout, zapLevel)
 	logger := zap.New(core)
 
 	zap.ReplaceGlobals(logger)

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -69,7 +69,7 @@ func (c *CLI) init() {
 
 	// TODO: We can make this optional? and more configurable if we see the need
 	// Initialize logger
-	InitGlobalLogger(DebugLevel)
+	_, _ = InitGlobalLogger(DebugLevel)
 	setupCloseHandler(nil)
 	// Set Configuration Defaults
 	setupDefaultConfiguration(func() {

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -69,7 +69,7 @@ func (c *CLI) init() {
 
 	// TODO: We can make this optional? and more configurable if we see the need
 	// Initialize logger
-	InitGlobalLogger()
+	InitGlobalLogger(DebugLevel)
 	setupCloseHandler(nil)
 	// Set Configuration Defaults
 	setupDefaultConfiguration(func() {


### PR DESCRIPTION
This Pull Request refactors the InitGlobalLogger function to accept a log level as a string. The change makes it easier to configure the logger by simply passing in a string that represents the desired log level.