### PR TITLE
Fixed Table and Where clauses in zDatabase

### DIFF
--- a/pkg/zdb/methods.go
+++ b/pkg/zdb/methods.go
@@ -51,7 +51,7 @@ func (z *zDatabase) Raw(sql string, values ...interface{}) ZDatabase {
 }
 
 func (z *zDatabase) Table(name string, args ...interface{}) ZDatabase {
-	return wrap(z.db.Table(name, args))
+	return wrap(z.db.Table(name, args...))
 }
 
 func (z *zDatabase) Clauses(conds ...clause.Expression) ZDatabase {
@@ -79,7 +79,7 @@ func (z *zDatabase) Order(value interface{}) ZDatabase {
 }
 
 func (z *zDatabase) Distinct(args ...interface{}) ZDatabase {
-	return wrap(z.db.Distinct(args))
+	return wrap(z.db.Distinct(args...))
 }
 
 func (z *zDatabase) Group(name string) ZDatabase {


### PR DESCRIPTION
## Unexpected `Where` Clause Output with zdb: Value Interpreted as Empty Array

When attempting to construct a query using zdb with a `Where` condition, the specified column value was not interpolating correctly.

### Original Code:

```go
db.
    Table(queries.CanonicalTrueField+queries.AllFields).
    Select("some field").
    Where("height = ?", height)
```

erroneous output

```go
WHERE height = '[]'
```

Despite passing a value for the height condition, Form was interpreting it as an empty array ([]).