### PR TITLE
Update logger to facilitate the use of global logger

### DIFF
--- a/.github/workflows/checks.golang.yml
+++ b/.github/workflows/checks.golang.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: true
       - uses: actions/setup-go@v3

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,12 @@ check-modtidy:
 	go mod tidy
 	git diff --exit-code -- go.mod go.sum
 
+fmt:
+	gofmt -l -s -w .
+
+vet:
+	go vet ./...
+
 lint:
 	golangci-lint --version
 	golangci-lint run

--- a/cmd/demo-cli/main.go
+++ b/cmd/demo-cli/main.go
@@ -13,6 +13,7 @@ func main() {
 		EnvPrefix:   "golem",
 		GitVersion:  version.GitVersion,
 		GitRevision: version.GitRevision,
+		LogLevel:    "debug"
 	}
 
 	// Define application level features

--- a/cmd/demo-cli/main.go
+++ b/cmd/demo-cli/main.go
@@ -13,7 +13,7 @@ func main() {
 		EnvPrefix:   "golem",
 		GitVersion:  version.GitVersion,
 		GitRevision: version.GitRevision,
-		LogLevel:    "debug"
+		LogLevel:    "debug",
 	}
 
 	// Define application level features

--- a/pkg/cli/config.go
+++ b/pkg/cli/config.go
@@ -1,7 +1,6 @@
 package cli
 
 import (
-	"context"
 	"fmt"
 	"github.com/zondax/golem/pkg/logger"
 	"strings"
@@ -15,7 +14,7 @@ func SetupConfiguration(c *cobra.Command) {
 	c.PersistentFlags().StringVarP(&configFileFlag, "config", "c", "", "The path to the config file to use.")
 	err := viper.BindPFlag("config", c.PersistentFlags().Lookup("config"))
 	if err != nil {
-		logger.GetLoggerFromContext(context.Background()).Fatalf("unable to bind config flag: %+v", err)
+		logger.Fatalf("unable to bind config flag: %+v", err)
 	}
 
 	viper.SetConfigName("config") // config file name without extension
@@ -50,12 +49,12 @@ func LoadConfig[T Config]() (*T, error) {
 	configFileOverride := viper.GetString("config")
 	if configFileOverride != "" {
 		viper.SetConfigFile(configFileOverride)
-		logger.GetLoggerFromContext(context.Background()).Infof("Using config file: %s", viper.ConfigFileUsed())
+		logger.Infof("Using config file: %s", viper.ConfigFileUsed())
 	}
 
 	err = viper.ReadInConfig()
 	if err != nil {
-		logger.GetLoggerFromContext(context.Background()).Fatalf("%+v", err)
+		logger.Fatalf("%+v", err)
 	}
 
 	// adds all default+configFile values in viper to struct

--- a/pkg/cli/handlers.go
+++ b/pkg/cli/handlers.go
@@ -21,7 +21,7 @@ func setupCloseHandler(handler CleanUpHandler) {
 			handler()
 		}
 
-		logger.Sync() // Sync logger
+		_ = logger.Sync() // Sync logger
 		// TODO: friendly closing callback
 		os.Exit(0)
 	}()

--- a/pkg/cli/handlers.go
+++ b/pkg/cli/handlers.go
@@ -1,11 +1,11 @@
 package cli
 
 import (
-	"context"
-	"github.com/zondax/golem/pkg/logger"
 	"os"
 	"os/signal"
 	"syscall"
+
+	"github.com/zondax/golem/pkg/logger"
 )
 
 var defaultConfigHandler DefaultConfigHandler
@@ -15,13 +15,13 @@ func setupCloseHandler(handler CleanUpHandler) {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
-		logger.GetLoggerFromContext(context.Background()).Warn("\r- Ctrl+C pressed in Terminal")
+		logger.Warn("\r- Ctrl+C pressed in Terminal")
 
 		if handler != nil {
 			handler()
 		}
 
-		_ = logger.Sync() // Sync logger
+		logger.Sync() // Sync logger
 		// TODO: friendly closing callback
 		os.Exit(0)
 	}()

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -96,11 +96,11 @@ func (c *CLI) GetVersionString() string {
 func (c *CLI) Run() {
 	if err := c.rootCmd.Execute(); err != nil {
 		logger.Error(err.Error())
-		logger.Sync()
+		_ = logger.Sync()
 		os.Exit(1)
 	}
 }
 
 func (c *CLI) Close() {
-	logger.Sync()
+	_ = logger.Sync()
 }

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -2,11 +2,11 @@ package cli
 
 import (
 	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/zondax/golem/pkg/constants"
 	"github.com/zondax/golem/pkg/logger"
-	"os"
 )
 
 type AppSettings struct {
@@ -16,6 +16,7 @@ type AppSettings struct {
 	EnvPrefix   string // environment variable MYAPP_.....
 	GitVersion  string
 	GitRevision string
+	LogLevel    string // Global log level for the app
 }
 
 type CLI struct {
@@ -50,9 +51,9 @@ func (c *CLI) init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := c.checkConfig()
 			if err != nil {
-				fmt.Printf("%s\n", c.checkConfig().Error())
+				logger.Errorf("%s\n", c.checkConfig().Error())
 			} else {
-				fmt.Printf("Configuration OK\n")
+				logger.Infof("Configuration OK\n")
 			}
 		},
 	}
@@ -61,15 +62,18 @@ func (c *CLI) init() {
 		Use:   "version",
 		Short: "Print version",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Printf("%s\n", c.GetVersionString())
+			logger.Infof("%s\n", c.GetVersionString())
 		},
 	}
 
 	c.GetRoot().AddCommand(checkCmd)
 	c.GetRoot().AddCommand(versionCmd)
 
-	// TODO: We can make this optional? and more configurable if we see the need
-	logger.InitLogger(logger.Config{Level: constants.DebugLevel})
+	// If app log level is defined it is configued, logger.defaultConfig by default
+	if len(c.app.LogLevel) > 0 {
+		logger.InitLogger(logger.Config{Level: c.app.LogLevel})
+	}
+
 	setupCloseHandler(nil)
 	// Set Configuration Defaults
 	setupDefaultConfiguration(func() {
@@ -91,15 +95,12 @@ func (c *CLI) GetVersionString() string {
 
 func (c *CLI) Run() {
 	if err := c.rootCmd.Execute(); err != nil {
-		_, err := fmt.Fprintln(os.Stderr, err)
-		if err != nil {
-			return
-		}
-		_ = logger.Sync()
+		logger.Error(err.Error())
+		logger.Sync()
 		os.Exit(1)
 	}
 }
 
 func (c *CLI) Close() {
-	_ = logger.Sync()
+	logger.Sync()
 }

--- a/pkg/logger/README.md
+++ b/pkg/logger/README.md
@@ -1,40 +1,174 @@
-# logger package
+# Logger Package
 
-The logger package is intended to make unified log management in the whole app
+A structured logging package built on top of [uber-go/zap](https://github.com/uber-go/zap), providing both global and context-aware logging capabilities with sensible defaults.
 
-The log may be used in 2 ways:
+## Features
 
-- Global: easy use of the global logger without the need to init or configure. 
+- Built on top of the high-performance zap logger
+- Supports both structured and printf-style logging
+- Context-aware logging
+- Global and instance-based logging
+- Configurable log levels and encoding formats
+- Request ID tracking support
+- Easy integration with existing applications
+
+## Installation
+
+```go
+go get -u go.uber.org/zap
 ```
-package main
 
-import (
-    "github.com/zondax/golem/pkg/logger"
+## Quick Start
+
+```go
+// Initialize with default configuration
+logger.InitLogger(logger.Config{
+    Level:    "info",
+    Encoding: "json",
+})
+
+// Basic logging
+logger.Info("Server started")
+logger.Error("Connection failed")
+
+// Structured logging with fields
+log := logger.NewLogger(
+    logger.Field{Key: "service", Value: "api"},
+    logger.Field{Key: "version", Value: "1.0.0"},
 )
+log.Info("Service initialized")
+```
 
-func main() {
-    // Importing logger global logger is configured in info level and may be used
-    logger.Info("Log info message")
+## Configuration
 
-    // Reconfigure global logger with config
-    logger.SetGlobalConfig(logger.Config{Level: "debug"})
-    logger.Info("Log debug message")
-    logger.Sync()
+### Logger Config
+
+```go
+type Config struct {
+    Level    string `json:"level"`    // Logging level
+    Encoding string `json:"encoding"` // Output format
 }
 ```
 
-- Local: use distinct logger for the package
-```
-package main
+### Log Levels
 
-import (
-    "github.com/zondax/golem/pkg/logger"
-)
+Available log levels (in order of increasing severity):
+- `debug`: Detailed information for debugging
+- `info`: General operational information
+- `warn`: Warning messages for potentially harmful situations
+- `error`: Error conditions that should be addressed
+- `dpanic`: Critical errors in development that cause panic
+- `panic`: Critical errors that cause panic in production
+- `fatal`: Fatal errors that terminate the program
 
-func main() {
-    // Generate new logger with options and use it
-    log := logger.NewLogger(opts ...interface{})
-    log.Info("Log info message")
-    log.Sync()
-}
+### Encoding Formats
+
+1. **JSON Format** (Default)
+   - Recommended for production
+   - Machine-readable structured output
+   ```json
+   {"level":"INFO","ts":"2024-03-20T10:00:00.000Z","msg":"Server started","service":"api"}
+   ```
+
+2. **Console Format**
+   - Recommended for development
+   - Human-readable output
+   ```
+   2024-03-20T10:00:00.000Z INFO Server started service=api
+   ```
+
+## Advanced Usage
+
+### Context-Aware Logging
+
+```go
+// Create a context with logger
+ctx := context.Background()
+log := logger.NewLogger(logger.Field{
+    Key: logger.RequestIDKey,
+    Value: "req-123",
+})
+ctx = logger.ContextWithLogger(ctx, log)
+
+// Get logger from context
+contextLogger := logger.GetLoggerFromContext(ctx)
+contextLogger.Info("Processing request")
 ```
+
+### Structured Logging with Fields
+
+```go
+log := logger.NewLogger()
+log.WithFields(
+    zap.String("user_id", "12345"),
+    zap.String("action", "login"),
+    zap.Int("attempt", 1),
+).Info("User login attempt")
+```
+
+### Printf-Style Logging
+
+```go
+logger.Infof("Processing item %d of %d", current, total)
+logger.Errorf("Failed to connect to %s: %v", host, err)
+```
+
+## Best Practices
+
+1. **Use Structured Logging**
+   ```go
+   // Good
+   log.WithFields(
+       zap.String("user_id", "12345"),
+       zap.String("action", "purchase"),
+       zap.Float64("amount", 99.99),
+   ).Info("Purchase completed")
+
+   // Avoid
+   log.Infof("User %s completed purchase of $%.2f", userID, amount)
+   ```
+
+2. **Include Request IDs**
+   ```go
+   log.WithFields(
+       zap.String(logger.RequestIDKey, requestID),
+   ).Info("Handling request")
+   ```
+
+3. **Proper Error Logging**
+   ```go
+   if err != nil {
+       log.WithFields(
+           zap.Error(err),
+           zap.String("operation", "database_query"),
+       ).Error("Query failed")
+   }
+   ```
+
+4. **Resource Cleanup**
+   ```go
+   defer logger.Sync()
+   ```
+
+## Performance Considerations
+
+- The logger is designed to be zero-allocation in most cases
+- JSON encoding is more CPU-intensive but provides structured data
+- Log level checks are performed atomically
+- Field allocation is optimized for minimal overhead
+
+## Thread Safety
+
+The logger is completely thread-safe and can be used concurrently from multiple goroutines.
+
+## Contributing
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request
+
+## License
+
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/pkg/logger/README.md
+++ b/pkg/logger/README.md
@@ -15,7 +15,7 @@ A structured logging package built on top of [uber-go/zap](https://github.com/ub
 ## Installation
 
 ```go
-go get -u go.uber.org/zap
+go get -u github.com/zondax/golem/pkg/logger
 ```
 
 ## Quick Start
@@ -160,15 +160,3 @@ logger.Errorf("Failed to connect to %s: %v", host, err)
 ## Thread Safety
 
 The logger is completely thread-safe and can be used concurrently from multiple goroutines.
-
-## Contributing
-
-1. Fork the repository
-2. Create your feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add some amazing feature'`)
-4. Push to the branch (`git push origin feature/amazing-feature`)
-5. Open a Pull Request
-
-## License
-
-This project is licensed under the MIT License - see the LICENSE file for details.

--- a/pkg/logger/README.md
+++ b/pkg/logger/README.md
@@ -1,0 +1,40 @@
+# logger package
+
+The logger package is intended to make unified log management in the whole app
+
+The log may be used in 2 ways:
+
+- Global: easy use of the global logger without the need to init or configure. 
+```
+package main
+
+import (
+    "github.com/zondax/golem/pkg/logger"
+)
+
+func main() {
+    // Importing logger global logger is configured in info level and may be used
+    logger.Info("Log info message")
+
+    // Reconfigure global logger with config
+    logger.SetGlobalConfig(logger.Config{Level: "debug"})
+    logger.Info("Log debug message")
+    logger.Sync()
+}
+```
+
+- Local: use distinct logger for the package
+```
+package main
+
+import (
+    "github.com/zondax/golem/pkg/logger"
+)
+
+func main() {
+    // Generate new logger with options and use it
+    log := logger.NewLogger(opts ...interface{})
+    log.Info("Log info message")
+    log.Sync()
+}
+```

--- a/pkg/logger/global.go
+++ b/pkg/logger/global.go
@@ -1,0 +1,88 @@
+package logger
+
+import (
+	"go.uber.org/zap"
+)
+
+func ReplaceGlobals(logger *zap.Logger) func() {
+	return zap.ReplaceGlobals(logger)
+}
+
+func SetGlobalConfig(config Config) func() {
+	logger := configureAndBuildLogger(config)
+	return ReplaceGlobals(logger)
+}
+
+func L() *zap.Logger {
+	return zap.L()
+}
+
+func S() *zap.SugaredLogger {
+	return zap.S()
+}
+
+func Info(msg string) {
+	L().Info(msg)
+}
+
+func Debug(msg string) {
+	L().Debug(msg)
+}
+
+func Warn(msg string) {
+	L().Warn(msg)
+}
+
+func Error(msg string) {
+	L().Error(msg)
+}
+
+func DPanic(msg string) {
+	L().DPanic(msg)
+}
+
+func Panic(msg string) {
+	L().Panic(msg)
+}
+
+func Fatal(msg string) {
+	L().Fatal(msg)
+}
+
+func Infof(template string, args ...interface{}) {
+	S().Infof(template, args...)
+}
+
+func Debugf(template string, args ...interface{}) {
+	S().Debugf(template, args...)
+}
+
+func Warnf(template string, args ...interface{}) {
+	S().Warnf(template, args...)
+}
+
+func Errorf(template string, args ...interface{}) {
+	S().Errorf(template, args...)
+}
+
+func DPanicf(template string, args ...interface{}) {
+	S().DPanicf(template, args...)
+}
+
+func Panicf(template string, args ...interface{}) {
+	S().Panicf(template, args...)
+}
+
+func Fatalf(template string, args ...interface{}) {
+	S().Fatalf(template, args...)
+}
+
+func Sync() error {
+	// Sync global logger
+	err := L().Sync()
+	if err != nil {
+		return err
+	}
+	// Sync global sugar logger
+	return S().Sync()
+}

--- a/pkg/logger/methods.go
+++ b/pkg/logger/methods.go
@@ -71,7 +71,7 @@ func (l *Logger) WithFields(fields ...zap.Field) *Logger {
 }
 
 func (l *Logger) IsDebugEnabled() bool {
-	return baseLogger.Core().Enabled(zap.DebugLevel)
+	return l.logger.Core().Enabled(zap.DebugLevel)
 }
 
 func GetLoggerFromContext(ctx context.Context) *Logger {

--- a/pkg/metrics/prometheus.go
+++ b/pkg/metrics/prometheus.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"context"
 	"fmt"
 	"github.com/go-chi/chi/v5"
 	"github.com/prometheus/client_golang/prometheus"
@@ -64,7 +63,7 @@ func (t *taskMetrics) AppName() string {
 func (t *taskMetrics) Start() error {
 	router := chi.NewRouter()
 
-	logger.GetLoggerFromContext(context.Background()).Infof("Metrics (prometheus) starting: %v", t.port)
+	logger.Infof("Metrics (prometheus) starting: %v", t.port)
 
 	// Prometheus path
 	router.Get(t.path, promhttp.Handler().(http.HandlerFunc))
@@ -77,12 +76,13 @@ func (t *taskMetrics) Start() error {
 
 	err := server.ListenAndServe()
 	if err != nil {
-		logger.GetLoggerFromContext(context.Background()).Errorf("Prometheus server error: %v", err)
-	} else {
-		logger.GetLoggerFromContext(context.Background()).Errorf("Prometheus server serving at port %s", t.port)
+		logger.Errorf("Prometheus server error: %v", err)
+		return err
 	}
 
-	return err
+	logger.Infof("Prometheus server serving at port %s", t.port)
+
+	return nil
 }
 
 func (t *taskMetrics) Stop() error {

--- a/pkg/metrics/service_metrics.go
+++ b/pkg/metrics/service_metrics.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"context"
 	"github.com/shirou/gopsutil/cpu"
 	"github.com/shirou/gopsutil/net"
 	"github.com/zondax/golem/pkg/logger"
@@ -46,34 +45,34 @@ func UpdateSystemMetrics(metricsServer TaskMetrics, updateInterval time.Duration
 		var m runtime.MemStats
 		runtime.ReadMemStats(&m)
 		if err := metricsServer.UpdateMetric(memoryUsageBytes, float64(m.Alloc)); err != nil {
-			logger.GetLoggerFromContext(context.Background()).Errorf("error updating %v: %v", memoryUsageBytes, err)
+			logger.Errorf("error updating %v: %v", memoryUsageBytes, err)
 		}
 
 		cpuPercents, _ := cpu.Percent(time.Second, false)
 		if err := metricsServer.UpdateMetric(cpuUsagePercent, cpuPercents[0]); err != nil {
-			logger.GetLoggerFromContext(context.Background()).Errorf("error updating %v: %v", cpuUsagePercent, err)
+			logger.Errorf("error updating %v: %v", cpuUsagePercent, err)
 		}
 
 		netIO, _ := net.IOCounters(false)
 		if err := metricsServer.UpdateMetric(bytesSent, float64(netIO[0].BytesSent)); err != nil {
-			logger.GetLoggerFromContext(context.Background()).Errorf("error updating %v: %v", bytesSent, err)
+			logger.Errorf("error updating %v: %v", bytesSent, err)
 		}
 		if err := metricsServer.UpdateMetric(bytesReceived, float64(netIO[0].BytesRecv)); err != nil {
-			logger.GetLoggerFromContext(context.Background()).Errorf("error updating %v: %v", bytesReceived, err)
+			logger.Errorf("error updating %v: %v", bytesReceived, err)
 		}
 
 		conns, _ := net.Connections("all")
 		if err := metricsServer.UpdateMetric(activeConnections, float64(len(conns))); err != nil {
-			logger.GetLoggerFromContext(context.Background()).Errorf("error updating %v: %v", activeConnections, err)
+			logger.Errorf("error updating %v: %v", activeConnections, err)
 		}
 
 		if err := metricsServer.UpdateMetric(goroutinesCount, float64(runtime.NumGoroutine())); err != nil {
-			logger.GetLoggerFromContext(context.Background()).Errorf("error updating %v: %v", goroutinesCount, err)
+			logger.Errorf("error updating %v: %v", goroutinesCount, err)
 		}
 
 		threads := pprof.Lookup("threadcreate").Count()
 		if err := metricsServer.UpdateMetric(threadsCount, float64(threads)); err != nil {
-			logger.GetLoggerFromContext(context.Background()).Errorf("error updating %v: %v", threadsCount, err)
+			logger.Errorf("error updating %v: %v", threadsCount, err)
 		}
 
 		time.Sleep(updateInterval)

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -62,7 +62,6 @@ func (tr *TaskRunner) sendError(te TaskError) {
 	case tr.errCh <- te:
 		break
 	default:
-		// FIXME: log error at least? Nobody is registered to receive errors
 		logger.Errorf("No receiver ready! error not sent! %s\n", te.Err.Error())
 	}
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -3,11 +3,13 @@ package runner
 import (
 	"context"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/zondax/golem/pkg/logger"
+	"golang.org/x/sync/errgroup"
 )
 
 type Task interface {
@@ -61,7 +63,7 @@ func (tr *TaskRunner) sendError(te TaskError) {
 		break
 	default:
 		// FIXME: log error at least? Nobody is registered to receive errors
-		fmt.Printf("No receiver ready! error not sent! %s\n", te.Err.Error())
+		logger.Errorf("No receiver ready! error not sent! %s\n", te.Err.Error())
 	}
 }
 
@@ -105,7 +107,7 @@ func (tr *TaskRunner) StartAndWait() {
 	tr.Start()
 	err := tr.Wait()
 	if err != nil {
-		fmt.Println("Error waiting for tasks to finish: ", err)
+		logger.Errorf("Waiting for tasks to finish: ", err)
 	}
 }
 


### PR DESCRIPTION
This PR add the chance to use global zap logger within the packages. Also some code cleanup has been done, like remove the logger mutex due to zap package already take care of them

<!-- ClickUpRef: 8696dxv0b -->
:link: [zboto Link](https://app.clickup.com/t/8696dxv0b)