### PR TITLE
generate a warning when a default logger is created

### DIFF
--- a/pkg/logger/methods.go
+++ b/pkg/logger/methods.go
@@ -2,6 +2,7 @@ package logger
 
 import (
 	"context"
+
 	"go.uber.org/zap"
 )
 
@@ -77,7 +78,9 @@ func (l *Logger) IsDebugEnabled() bool {
 func GetLoggerFromContext(ctx context.Context) *Logger {
 	logger, ok := ctx.Value(loggerKey).(*Logger)
 	if !ok {
-		return NewLogger()
+		newLogger := NewLogger()
+		newLogger.Warnf("Logger had to be created without configuration because the context was missing")
+		return newLogger
 	}
 	return logger
 }


### PR DESCRIPTION
Sometimes we are created loggers that have no configuration.
In these cases, we should log a warning.