### PR TITLE
Enable filtering traces by method on zobservability

### DIFF
--- a/pkg/zobservability/README.md
+++ b/pkg/zobservability/README.md
@@ -174,10 +174,19 @@ zobservability:
   sample_rate: 1.0
   middleware:
     capture_errors: true
-  tracing_exclusions:  # Optional: List of method names to exclude from tracing
+  tracing_exclusions:  # Optional: List of operations/endpoints to exclude from tracing
+    # Direct operation names
     - "HealthCheck"
     - "Ping"
     - "GetMetrics"
+    # gRPC methods (full path)
+    - "/grpc.health.v1.Health/Check"
+    - "/grpc.health.v1.Health/Watch"
+    - "/grpc.reflection.v1alpha.ServerReflection/ServerReflectionInfo"
+    # HTTP routes
+    - "/health"
+    - "/metrics"
+    - "/api/v1/health"
   metrics:
     enabled: true
     provider: "opentelemetry"

--- a/pkg/zobservability/README.md
+++ b/pkg/zobservability/README.md
@@ -76,6 +76,11 @@ zobservability/
 - Batch processing configuration
 - Resource attribute customization
 
+### Tracing Exclusions
+- Selective tracing with method exclusion support
+- Performance optimization for high-frequency endpoints
+- Reduce noise from health checks and metrics endpoints
+
 ### External API Monitoring
 - Automatic detection and monitoring of external service calls
 
@@ -169,6 +174,10 @@ zobservability:
   sample_rate: 1.0
   middleware:
     capture_errors: true
+  tracing_exclusions:  # Optional: List of method names to exclude from tracing
+    - "HealthCheck"
+    - "Ping"
+    - "GetMetrics"
   metrics:
     enabled: true
     provider: "opentelemetry"
@@ -431,6 +440,80 @@ observer.CaptureException(ctx, err, zobservability.WithLevel(zobservability.Leve
 // Capture messages
 observer.CaptureMessage(ctx, "User login failed", zobservability.LevelWarning)
 ```
+
+## Tracing Exclusions
+
+The tracing exclusions feature allows you to selectively exclude specific methods or operations from being traced. This is particularly useful for:
+
+- **High-frequency endpoints**: Health checks, metrics endpoints that would generate excessive trace data
+- **Performance optimization**: Reduce overhead on operations that don't need monitoring
+- **Noise reduction**: Keep your traces focused on business-critical operations
+
+### Configuration
+
+Add the `tracing_exclusions` list to your configuration:
+
+```yaml
+zobservability:
+  provider: "signoz"
+  enabled: true
+  tracing_exclusions:
+    - "HealthCheck"           # Exclude health check endpoints
+    - "Ping"                  # Exclude ping/heartbeat endpoints
+    - "GetMetrics"            # Exclude metrics collection
+    - "db.query.select_health" # Exclude specific database queries
+    - "cache.get"             # Exclude cache operations
+```
+
+### How It Works
+
+When a method name matches an entry in the `tracing_exclusions` list:
+- The method returns a no-op transaction or span that performs no operations
+- No trace data is sent to the observability backend
+- Child spans of excluded transactions are also excluded
+- The method continues to execute normally, just without tracing
+
+### Usage Example
+
+```go
+// Configuration with exclusions
+config := &zobservability.Config{
+    Provider: zobservability.ProviderSigNoz,
+    Enabled: true,
+    TracingExclusions: []string{
+        "HealthCheck",
+        "GetMetrics",
+        "cache.get",
+    },
+}
+
+observer, _ := factory.NewObserver(config, "my-service")
+
+// This transaction will be excluded (no-op)
+tx1 := observer.StartTransaction(ctx, "HealthCheck")
+tx1.SetTag("key", "value") // No-op, does nothing
+tx1.Finish(zobservability.TransactionOK) // No-op, does nothing
+
+// This transaction will be traced normally
+tx2 := observer.StartTransaction(ctx, "ProcessOrder")
+tx2.SetTag("order_id", "12345") // Actually sets the tag
+tx2.Finish(zobservability.TransactionOK) // Sends trace to backend
+
+// Spans work the same way
+_, span1 := observer.StartSpan(ctx, "cache.get") // Excluded (no-op)
+span1.Finish() // No-op
+
+_, span2 := observer.StartSpan(ctx, "db.query.insert") // Traced normally
+span2.Finish() // Sends span to backend
+```
+
+### Best Practices
+
+1. **Be Specific**: Use exact method names to avoid accidentally excluding important operations
+2. **Case Sensitive**: Method names are case-sensitive - "HealthCheck" is different from "healthcheck"
+3. **No Wildcards**: The current implementation requires exact matches (no regex or wildcards)
+4. **Document Exclusions**: Keep a list of excluded methods in your documentation for debugging purposes
+5. **Monitor Impact**: Periodically review excluded methods to ensure you're not missing important data
 
 ## External API Monitoring
 

--- a/pkg/zobservability/config.go
+++ b/pkg/zobservability/config.go
@@ -11,17 +11,18 @@ type PropagationConfig struct {
 
 // Config holds configuration for all observability features (tracing, logging, metrics)
 type Config struct {
-	Provider     string            `yaml:"provider" mapstructure:"provider"`
-	Enabled      bool              `yaml:"enabled" mapstructure:"enabled"` // Enable/disable observability
-	Environment  string            `yaml:"environment" mapstructure:"environment"`
-	Release      string            `yaml:"release" mapstructure:"release"`
-	Debug        bool              `yaml:"debug" mapstructure:"debug"`
-	Address      string            `yaml:"address" mapstructure:"address"`         // Common endpoint/address/dsn for providers
-	SampleRate   float64           `yaml:"sample_rate" mapstructure:"sample_rate"` // Common sampling rate
-	Middleware   MiddlewareConfig  `yaml:"middleware" mapstructure:"middleware"`
-	Metrics      MetricsConfig     `yaml:"metrics" mapstructure:"metrics"`             // Metrics configuration
-	Propagation  PropagationConfig `yaml:"propagation" mapstructure:"propagation"`     // Trace propagation configuration
-	CustomConfig map[string]string `yaml:"custom_config" mapstructure:"custom_config"` // Provider-specific configuration
+	Provider                        string            `yaml:"provider" mapstructure:"provider"`
+	Enabled                         bool              `yaml:"enabled" mapstructure:"enabled"` // Enable/disable observability
+	Environment                     string            `yaml:"environment" mapstructure:"environment"`
+	Release                         string            `yaml:"release" mapstructure:"release"`
+	Debug                           bool              `yaml:"debug" mapstructure:"debug"`
+	Address                         string            `yaml:"address" mapstructure:"address"`         // Common endpoint/address/dsn for providers
+	SampleRate                      float64           `yaml:"sample_rate" mapstructure:"sample_rate"` // Common sampling rate
+	Middleware                      MiddlewareConfig  `yaml:"middleware" mapstructure:"middleware"`
+	Metrics                         MetricsConfig     `yaml:"metrics" mapstructure:"metrics"`             // Metrics configuration
+	Propagation                     PropagationConfig `yaml:"propagation" mapstructure:"propagation"`     // Trace propagation configuration
+	CustomConfig                    map[string]string `yaml:"custom_config" mapstructure:"custom_config"` // Provider-specific configuration
+	InterceptorTracingExcludeMethods []string         `yaml:"interceptor_tracing_exclude_methods" mapstructure:"interceptor_tracing_exclude_methods"` // Methods to exclude from tracing
 }
 
 func (c Config) Validate() error {
@@ -71,4 +72,7 @@ func (c *Config) SetDefaults() {
 	if len(c.Propagation.Formats) == 0 {
 		c.Propagation.Formats = []string{PropagationB3} // Default to B3 because is the only one supported by GCP+Signoz
 	}
+
+	// InterceptorTracingExcludeMethods will be configured via YAML or environment variables
+	// No hardcoded defaults here
 }

--- a/pkg/zobservability/config.go
+++ b/pkg/zobservability/config.go
@@ -11,18 +11,18 @@ type PropagationConfig struct {
 
 // Config holds configuration for all observability features (tracing, logging, metrics)
 type Config struct {
-	Provider                        string            `yaml:"provider" mapstructure:"provider"`
-	Enabled                         bool              `yaml:"enabled" mapstructure:"enabled"` // Enable/disable observability
-	Environment                     string            `yaml:"environment" mapstructure:"environment"`
-	Release                         string            `yaml:"release" mapstructure:"release"`
-	Debug                           bool              `yaml:"debug" mapstructure:"debug"`
-	Address                         string            `yaml:"address" mapstructure:"address"`         // Common endpoint/address/dsn for providers
-	SampleRate                      float64           `yaml:"sample_rate" mapstructure:"sample_rate"` // Common sampling rate
-	Middleware                      MiddlewareConfig  `yaml:"middleware" mapstructure:"middleware"`
-	Metrics      MetricsConfig     `yaml:"metrics" mapstructure:"metrics"`             // Metrics configuration
-	Propagation  PropagationConfig `yaml:"propagation" mapstructure:"propagation"`     // Trace propagation configuration
-	CustomConfig map[string]string `yaml:"custom_config" mapstructure:"custom_config"` // Provider-specific configuration
-	TracingExclusions []string     `yaml:"tracing_exclusions" mapstructure:"tracing_exclusions"` // gRPC methods to exclude from tracing
+	Provider          string            `yaml:"provider" mapstructure:"provider"`
+	Enabled           bool              `yaml:"enabled" mapstructure:"enabled"` // Enable/disable observability
+	Environment       string            `yaml:"environment" mapstructure:"environment"`
+	Release           string            `yaml:"release" mapstructure:"release"`
+	Debug             bool              `yaml:"debug" mapstructure:"debug"`
+	Address           string            `yaml:"address" mapstructure:"address"`         // Common endpoint/address/dsn for providers
+	SampleRate        float64           `yaml:"sample_rate" mapstructure:"sample_rate"` // Common sampling rate
+	Middleware        MiddlewareConfig  `yaml:"middleware" mapstructure:"middleware"`
+	Metrics           MetricsConfig     `yaml:"metrics" mapstructure:"metrics"`                       // Metrics configuration
+	Propagation       PropagationConfig `yaml:"propagation" mapstructure:"propagation"`               // Trace propagation configuration
+	CustomConfig      map[string]string `yaml:"custom_config" mapstructure:"custom_config"`           // Provider-specific configuration
+	TracingExclusions []string          `yaml:"tracing_exclusions" mapstructure:"tracing_exclusions"` // methods to exclude from tracing
 }
 
 func (c Config) Validate() error {
@@ -72,7 +72,4 @@ func (c *Config) SetDefaults() {
 	if len(c.Propagation.Formats) == 0 {
 		c.Propagation.Formats = []string{PropagationB3} // Default to B3 because is the only one supported by GCP+Signoz
 	}
-
-	// InterceptorTracingExcludeMethods will be configured via YAML or environment variables
-	// No hardcoded defaults here
 }

--- a/pkg/zobservability/config.go
+++ b/pkg/zobservability/config.go
@@ -19,10 +19,10 @@ type Config struct {
 	Address                         string            `yaml:"address" mapstructure:"address"`         // Common endpoint/address/dsn for providers
 	SampleRate                      float64           `yaml:"sample_rate" mapstructure:"sample_rate"` // Common sampling rate
 	Middleware                      MiddlewareConfig  `yaml:"middleware" mapstructure:"middleware"`
-	Metrics                         MetricsConfig     `yaml:"metrics" mapstructure:"metrics"`             // Metrics configuration
-	Propagation                     PropagationConfig `yaml:"propagation" mapstructure:"propagation"`     // Trace propagation configuration
-	CustomConfig                    map[string]string `yaml:"custom_config" mapstructure:"custom_config"` // Provider-specific configuration
-	InterceptorTracingExcludeMethods []string         `yaml:"interceptor_tracing_exclude_methods" mapstructure:"interceptor_tracing_exclude_methods"` // Methods to exclude from tracing
+	Metrics      MetricsConfig     `yaml:"metrics" mapstructure:"metrics"`             // Metrics configuration
+	Propagation  PropagationConfig `yaml:"propagation" mapstructure:"propagation"`     // Trace propagation configuration
+	CustomConfig map[string]string `yaml:"custom_config" mapstructure:"custom_config"` // Provider-specific configuration
+	TracingExclusions []string     `yaml:"tracing_exclusions" mapstructure:"tracing_exclusions"` // gRPC methods to exclude from tracing
 }
 
 func (c Config) Validate() error {

--- a/pkg/zobservability/examples/config_example.yaml
+++ b/pkg/zobservability/examples/config_example.yaml
@@ -11,6 +11,10 @@ observability:
   release: "v1.2.3"
   headers:
     signoz-access-token: "your-signoz-access-token"
+  tracing_exclusions:  # Optional: exclude high-frequency endpoints
+    - "HealthCheck"
+    - "Ping"
+    - "GetMetrics"
   metrics:
     enabled: true
     provider: "opentelemetry"

--- a/pkg/zobservability/factory/factory.go
+++ b/pkg/zobservability/factory/factory.go
@@ -119,19 +119,20 @@ func newSigNozObserver(config *zobservability.Config, serviceName string) (zobse
 
 	// Create SigNoz configuration with all parsed settings
 	signozConfig := &signoz.Config{
-		Endpoint:             config.Address,
-		ServiceName:          serviceName,
-		Environment:          config.Environment,
-		Release:              config.Release,
-		Debug:                config.Debug,
-		Insecure:             insecure,
-		Headers:              headers,
-		SampleRate:           config.SampleRate,
-		BatchConfig:          batchConfig,          // Optional: nil means use defaults
-		ResourceConfig:       resourceConfig,       // Optional: nil means use defaults
-		IgnoreParentSampling: ignoreParentSampling, // Critical for Google Cloud Run deployments
-		UseSimpleSpan:        useSimpleSpan,        // Enable immediate span export
-		Propagation:          config.Propagation,   // Copy propagation configuration
+		Endpoint:                         config.Address,
+		ServiceName:                      serviceName,
+		Environment:                      config.Environment,
+		Release:                          config.Release,
+		Debug:                            config.Debug,
+		Insecure:                         insecure,
+		Headers:                          headers,
+		SampleRate:                       config.SampleRate,
+		BatchConfig:                      batchConfig,          // Optional: nil means use defaults
+		ResourceConfig:                   resourceConfig,       // Optional: nil means use defaults
+		IgnoreParentSampling:             ignoreParentSampling, // Critical for Google Cloud Run deployments
+		UseSimpleSpan:                    useSimpleSpan,        // Enable immediate span export
+		Propagation:                      config.Propagation,   // Copy propagation configuration
+		InterceptorTracingExcludeMethods: config.InterceptorTracingExcludeMethods, // Pass filtered methods
 	}
 
 	return signoz.NewObserver(signozConfig)

--- a/pkg/zobservability/factory/factory.go
+++ b/pkg/zobservability/factory/factory.go
@@ -119,20 +119,20 @@ func newSigNozObserver(config *zobservability.Config, serviceName string) (zobse
 
 	// Create SigNoz configuration with all parsed settings
 	signozConfig := &signoz.Config{
-		Endpoint:                         config.Address,
-		ServiceName:                      serviceName,
-		Environment:                      config.Environment,
-		Release:                          config.Release,
-		Debug:                            config.Debug,
-		Insecure:                         insecure,
-		Headers:                          headers,
-		SampleRate:                       config.SampleRate,
-		BatchConfig:                      batchConfig,          // Optional: nil means use defaults
-		ResourceConfig:                   resourceConfig,       // Optional: nil means use defaults
+		Endpoint:             config.Address,
+		ServiceName:          serviceName,
+		Environment:          config.Environment,
+		Release:              config.Release,
+		Debug:                config.Debug,
+		Insecure:             insecure,
+		Headers:              headers,
+		SampleRate:           config.SampleRate,
+		BatchConfig:          batchConfig,          // Optional: nil means use defaults
+		ResourceConfig:       resourceConfig,       // Optional: nil means use defaults
 		IgnoreParentSampling: ignoreParentSampling, // Critical for Google Cloud Run deployments
 		UseSimpleSpan:        useSimpleSpan,        // Enable immediate span export
 		Propagation:          config.Propagation,   // Copy propagation configuration
-		TracingExclusions:    config.TracingExclusions, // Pass filtered methods
+		TracingExclusions:    config.TracingExclusions,
 	}
 
 	return signoz.NewObserver(signozConfig)

--- a/pkg/zobservability/factory/factory.go
+++ b/pkg/zobservability/factory/factory.go
@@ -129,10 +129,10 @@ func newSigNozObserver(config *zobservability.Config, serviceName string) (zobse
 		SampleRate:                       config.SampleRate,
 		BatchConfig:                      batchConfig,          // Optional: nil means use defaults
 		ResourceConfig:                   resourceConfig,       // Optional: nil means use defaults
-		IgnoreParentSampling:             ignoreParentSampling, // Critical for Google Cloud Run deployments
-		UseSimpleSpan:                    useSimpleSpan,        // Enable immediate span export
-		Propagation:                      config.Propagation,   // Copy propagation configuration
-		InterceptorTracingExcludeMethods: config.InterceptorTracingExcludeMethods, // Pass filtered methods
+		IgnoreParentSampling: ignoreParentSampling, // Critical for Google Cloud Run deployments
+		UseSimpleSpan:        useSimpleSpan,        // Enable immediate span export
+		Propagation:          config.Propagation,   // Copy propagation configuration
+		TracingExclusions:    config.TracingExclusions, // Pass filtered methods
 	}
 
 	return signoz.NewObserver(signozConfig)

--- a/pkg/zobservability/noop.go
+++ b/pkg/zobservability/noop.go
@@ -63,7 +63,7 @@ func (n *noopObserver) GetConfig() Config {
 			Port:          9090,
 			OpenTelemetry: DefaultOpenTelemetryMetricsConfig(),
 		},
-		InterceptorTracingExcludeMethods: []string{}, // No filtering for noop observer
+		TracingExclusions: []string{}, // No filtering for noop observer
 	}
 }
 

--- a/pkg/zobservability/noop.go
+++ b/pkg/zobservability/noop.go
@@ -63,6 +63,7 @@ func (n *noopObserver) GetConfig() Config {
 			Port:          9090,
 			OpenTelemetry: DefaultOpenTelemetryMetricsConfig(),
 		},
+		InterceptorTracingExcludeMethods: []string{}, // No filtering for noop observer
 	}
 }
 

--- a/pkg/zobservability/providers/sentry/provider.go
+++ b/pkg/zobservability/providers/sentry/provider.go
@@ -146,7 +146,7 @@ func (s *sentryObserver) GetConfig() zobservability.Config {
 		Middleware: zobservability.MiddlewareConfig{
 			CaptureErrors: s.config.CaptureErrors,
 		},
-		InterceptorTracingExcludeMethods: []string{},
+		TracingExclusions: []string{},
 	}
 }
 

--- a/pkg/zobservability/providers/sentry/provider.go
+++ b/pkg/zobservability/providers/sentry/provider.go
@@ -146,6 +146,7 @@ func (s *sentryObserver) GetConfig() zobservability.Config {
 		Middleware: zobservability.MiddlewareConfig{
 			CaptureErrors: s.config.CaptureErrors,
 		},
+		InterceptorTracingExcludeMethods: []string{},
 	}
 }
 

--- a/pkg/zobservability/providers/signoz/config.go
+++ b/pkg/zobservability/providers/signoz/config.go
@@ -49,7 +49,12 @@ type Config struct {
 	// Propagation configuration
 	Propagation zobservability.PropagationConfig `yaml:"propagation" mapstructure:"propagation"`
 
-	// TracingExclusions contains the list of methods to exclude from tracing
+	// TracingExclusions contains the list of operations/endpoints to exclude from tracing
+	// Supports:
+	// - Operation names: "authz.interceptor.Authorize"
+	// - gRPC methods: "/grpc.health.v1.Health/Check"
+	// - HTTP routes: "/api/v1/health", "/metrics"
+	// When a parent operation is excluded, all child spans are automatically excluded
 	TracingExclusions []string `yaml:"tracing_exclusions" mapstructure:"tracing_exclusions"`
 }
 

--- a/pkg/zobservability/providers/signoz/config.go
+++ b/pkg/zobservability/providers/signoz/config.go
@@ -49,7 +49,7 @@ type Config struct {
 	// Propagation configuration
 	Propagation zobservability.PropagationConfig `yaml:"propagation" mapstructure:"propagation"`
 
-	// TracingExclusions contains the list of gRPC methods to exclude from tracing
+	// TracingExclusions contains the list of methods to exclude from tracing
 	TracingExclusions []string `yaml:"tracing_exclusions" mapstructure:"tracing_exclusions"`
 }
 

--- a/pkg/zobservability/providers/signoz/config.go
+++ b/pkg/zobservability/providers/signoz/config.go
@@ -48,6 +48,9 @@ type Config struct {
 
 	// Propagation configuration
 	Propagation zobservability.PropagationConfig `yaml:"propagation" mapstructure:"propagation"`
+
+	// InterceptorTracingExcludeMethods contains the list of gRPC methods to exclude from tracing
+	InterceptorTracingExcludeMethods []string `yaml:"interceptor_tracing_exclude_methods" mapstructure:"interceptor_tracing_exclude_methods"`
 }
 
 // BatchConfig controls how spans are batched and sent to SigNoz

--- a/pkg/zobservability/providers/signoz/config.go
+++ b/pkg/zobservability/providers/signoz/config.go
@@ -49,8 +49,8 @@ type Config struct {
 	// Propagation configuration
 	Propagation zobservability.PropagationConfig `yaml:"propagation" mapstructure:"propagation"`
 
-	// InterceptorTracingExcludeMethods contains the list of gRPC methods to exclude from tracing
-	InterceptorTracingExcludeMethods []string `yaml:"interceptor_tracing_exclude_methods" mapstructure:"interceptor_tracing_exclude_methods"`
+	// TracingExclusions contains the list of gRPC methods to exclude from tracing
+	TracingExclusions []string `yaml:"tracing_exclusions" mapstructure:"tracing_exclusions"`
 }
 
 // BatchConfig controls how spans are batched and sent to SigNoz

--- a/pkg/zobservability/providers/signoz/provider.go
+++ b/pkg/zobservability/providers/signoz/provider.go
@@ -466,6 +466,6 @@ func (s *signozObserver) GetConfig() zobservability.Config {
 		Middleware: zobservability.MiddlewareConfig{
 			CaptureErrors: true,
 		},
-		InterceptorTracingExcludeMethods: s.config.InterceptorTracingExcludeMethods,
+		TracingExclusions: s.config.TracingExclusions,
 	}
 }

--- a/pkg/zobservability/providers/signoz/provider.go
+++ b/pkg/zobservability/providers/signoz/provider.go
@@ -26,6 +26,9 @@ import (
 // contextKey is a type for context keys specific to this package
 type contextKey string
 
+// httpRequestKey is a type for storing HTTP requests in context
+type httpRequestKey struct{}
+
 // Context keys for exclusion tracking
 const (
 	// contextKeyExcluded is used to mark contexts where tracing is excluded
@@ -78,7 +81,6 @@ func (s *signozObserver) shouldExcludeBasedOnContext(ctx context.Context, operat
 
 	// Check if there's an HTTP request in context (using chi's context or standard library)
 	// This is a fallback for when the route pattern is not explicitly set
-	type httpRequestKey struct{}
 	if req, ok := ctx.Value(httpRequestKey{}).(*http.Request); ok && req != nil {
 		path := req.URL.Path
 		if s.isOperationExcluded(path) {

--- a/pkg/zobservability/providers/signoz/provider.go
+++ b/pkg/zobservability/providers/signoz/provider.go
@@ -466,5 +466,6 @@ func (s *signozObserver) GetConfig() zobservability.Config {
 		Middleware: zobservability.MiddlewareConfig{
 			CaptureErrors: true,
 		},
+		InterceptorTracingExcludeMethods: s.config.InterceptorTracingExcludeMethods,
 	}
 }

--- a/pkg/zobservability/providers/signoz/provider_test.go
+++ b/pkg/zobservability/providers/signoz/provider_test.go
@@ -666,7 +666,7 @@ func TestSignozObserver_StartTransaction_WhenOperationExcluded_ShouldReturnNoopT
 			Provider: string(zobservability.MetricsProviderNoop),
 		},
 	}
-	
+
 	observer, err := NewObserver(config)
 	require.NoError(t, err)
 	require.NotNil(t, observer)
@@ -681,7 +681,7 @@ func TestSignozObserver_StartTransaction_WhenOperationExcluded_ShouldReturnNoopT
 	assert.NotNil(t, tx)
 	// The noop transaction should preserve the context
 	assert.Equal(t, ctx, tx.Context())
-	
+
 	// Operations on noop transaction should not panic
 	assert.NotPanics(t, func() {
 		tx.SetName("new-name")
@@ -711,7 +711,7 @@ func TestSignozObserver_StartTransaction_WhenOperationNotExcluded_ShouldReturnNo
 			Provider: string(zobservability.MetricsProviderNoop),
 		},
 	}
-	
+
 	observer, err := NewObserver(config)
 	require.NoError(t, err)
 	require.NotNil(t, observer)
@@ -726,7 +726,7 @@ func TestSignozObserver_StartTransaction_WhenOperationNotExcluded_ShouldReturnNo
 	assert.NotNil(t, tx)
 	// Should be a real transaction with trace context
 	assert.NotEqual(t, ctx, tx.Context())
-	
+
 	// Cleanup
 	tx.Finish(zobservability.TransactionOK)
 }
@@ -749,7 +749,7 @@ func TestSignozObserver_StartSpan_WhenOperationExcluded_ShouldReturnNoopSpan(t *
 			Provider: string(zobservability.MetricsProviderNoop),
 		},
 	}
-	
+
 	observer, err := NewObserver(config)
 	require.NoError(t, err)
 	require.NotNil(t, observer)
@@ -764,7 +764,7 @@ func TestSignozObserver_StartSpan_WhenOperationExcluded_ShouldReturnNoopSpan(t *
 	assert.NotNil(t, span)
 	// Context should be preserved (not modified)
 	assert.Equal(t, ctx, newCtx)
-	
+
 	// Operations on noop span should not panic
 	assert.NotPanics(t, func() {
 		span.SetTag("key", "value")
@@ -792,7 +792,7 @@ func TestSignozObserver_StartSpan_WhenOperationNotExcluded_ShouldReturnNormalSpa
 			Provider: string(zobservability.MetricsProviderNoop),
 		},
 	}
-	
+
 	observer, err := NewObserver(config)
 	require.NoError(t, err)
 	require.NotNil(t, observer)
@@ -807,7 +807,7 @@ func TestSignozObserver_StartSpan_WhenOperationNotExcluded_ShouldReturnNormalSpa
 	assert.NotNil(t, span)
 	// Should have trace context injected
 	assert.NotEqual(t, ctx, newCtx)
-	
+
 	// Cleanup
 	span.Finish()
 }
@@ -815,19 +815,19 @@ func TestSignozObserver_StartSpan_WhenOperationNotExcluded_ShouldReturnNormalSpa
 func TestSignozObserver_TracingExclusions_EmptyList_ShouldNotExcludeAnything(t *testing.T) {
 	// Arrange
 	config := &Config{
-		Endpoint:    "localhost:4317",
-		ServiceName: "test-service",
-		Environment: "test",
-		Release:     "1.0.0",
-		Insecure:    true,
-		SampleRate:  1.0,
+		Endpoint:          "localhost:4317",
+		ServiceName:       "test-service",
+		Environment:       "test",
+		Release:           "1.0.0",
+		Insecure:          true,
+		SampleRate:        1.0,
 		TracingExclusions: []string{}, // Empty exclusion list
 		Metrics: zobservability.MetricsConfig{
 			Enabled:  true,
 			Provider: string(zobservability.MetricsProviderNoop),
 		},
 	}
-	
+
 	observer, err := NewObserver(config)
 	require.NoError(t, err)
 	require.NotNil(t, observer)
@@ -851,7 +851,7 @@ func TestSignozObserver_isOperationExcluded(t *testing.T) {
 	exclusionsMap["health"] = true
 	exclusionsMap["metrics"] = true
 	exclusionsMap["debug/pprof"] = true
-	
+
 	observer := &signozObserver{
 		config: &Config{
 			TracingExclusions: []string{


### PR DESCRIPTION
<!-- ClickUpRef: 869a1xv09 -->
:link: [zboto Link](https://app.clickup.com/t/869a1xv09)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying methods and operations to exclude from tracing via a new configuration option.
  * Excluded operations return no-op transactions and spans that do not generate trace data, reducing noise and improving performance.
  * Tracing exclusions support direct operation names, gRPC methods, and HTTP routes with context-aware checks.
  * Configuration examples and documentation enhanced with guidance and best practices for using tracing exclusions.
  * Unit tests added to validate exclusion behavior and no-op span/transaction handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->